### PR TITLE
Fixed issue with getUserEmail

### DIFF
--- a/outlook-demo.js
+++ b/outlook-demo.js
@@ -424,7 +424,14 @@ $(function() {
               if (err) {
                 callback(null, err);
               } else {
-                callback(res.mail);
+                // Get result, which may be one of two values
+                // For Office 365 users, use the mail property
+                // For MSA users, use the userPrincipalName property
+                var email = res.mail ? res.mail : res.userPrincipalName;
+
+                // Store in session
+                sessionStorage.userEmail = email;
+                callback(email);
               }
             });
         } else {


### PR DESCRIPTION
MSA accounts always have their mail property set to null, so we need to fall back on userPrincipalName.

Also added code to actually save the email address in the session so subsequent calls will read from session.

Fixes #4